### PR TITLE
feat: experimental under attack mode

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,6 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: golang:bullseye
+    postgres:
+      image: postgres:15-bullseye
+      env:
+        POSTGRES_PASSWORD: password
+        POSTGRES_USER: captcha
+        POSTGRES_DB: captcha
+      options: >-
+        --health-cmd "pg_isready -U captcha -d captcha"
+        --health-interval 15s
+        --health-timeout 10s
+        --health-retries 5
+    mysql:
+      image: mysql:8
+      env:
+        MYSQL_USER: captcha
+        MYSQL_PASSWORD: password
+        MYSQL_DATABASE: captcha
+      options: >-
+        --health-cmd "mysqladmin ping -h localhost -u captcha --password=password"
+        --health-interval 10s
+        --health-timeout 5s
+        --health-retries 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: golang:bullseye
+    container: golang:1.19
     postgres:
       image: postgres:15-bullseye
       env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,6 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: golang:1.19
     postgres:
       image: postgres:15-bullseye
       env:
@@ -50,6 +49,10 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
 
       - name: Build
         run: go build .

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 10
     postgres:
       image: postgres:15-bullseye
+      ports:
+        - 5432:5432
       env:
         POSTGRES_PASSWORD: password
         POSTGRES_USER: captcha
@@ -27,6 +29,8 @@ jobs:
         --health-retries 5
     mysql:
       image: mysql:8
+      ports:
+        - 3306:3306
       env:
         MYSQL_USER: captcha
         MYSQL_PASSWORD: password
@@ -60,6 +64,8 @@ jobs:
       - name: Run test & coverage
         run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
         env:
+          POSTGRES_URL: postgres://captcha:password@localhost:5432/captcha?sslmode=disable
+          MYSQL_URL: captcha:password@tcp(localhost:3306)/captcha?parseTime=true
           ENVIRONMENT: development
           TZ: UTC
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,8 @@ jobs:
     services:
       postgres:
         image: postgres:15-bullseye
+        ports:
+          - 5432:5432
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: captcha
@@ -25,6 +27,8 @@ jobs:
           --health-start-period 60s
       mysql:
         image: mysql:8
+        ports:
+          - 3306:3306
         env:
           MYSQL_USER: captcha
           MYSQL_PASSWORD: password
@@ -60,8 +64,8 @@ jobs:
       - name: Run test & coverage
         run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
         env:
-          POSTGRES_URL: postgres://captcha:password@postgres:5432/captcha?sslmode=disable
-          MYSQL_URL: captcha:password@tcp(mysql:3306)/captcha?parseTime=true
+          POSTGRES_URL: postgres://captcha:password@localhost:5432/captcha?sslmode=disable
+          MYSQL_URL: captcha:password@tcp(localhost:3306)/captcha?parseTime=true
           ENVIRONMENT: development
           TZ: UTC
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: golang:bullseye
+    container: golang:1.19
     services:
       postgres:
         image: postgres:15-bullseye

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,6 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: golang:1.19
     services:
       postgres:
         image: postgres:15-bullseye
@@ -50,6 +49,10 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
 
       - name: Build
         run: go build .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: golang:bullseye
+    services:
+      postgres:
+        image: postgres:15-bullseye
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: captcha
+          POSTGRES_DB: captcha
+        options: >-
+          --health-cmd "pg_isready -U captcha -d captcha"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 5
+          --health-start-period 60s
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_USER: captcha
+          MYSQL_PASSWORD: password
+          MYSQL_DATABASE: captcha
+          MYSQL_ROOT_PASSWORD: password
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -u captcha --password=password"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 60s
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -31,6 +57,8 @@ jobs:
       - name: Run test & coverage
         run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
         env:
+          POSTGRES_URL: postgres://captcha:password@postgres:5432/captcha?sslmode=disable
+          MYSQL_URL: captcha:password@tcp(mysql:3306)/captcha?parseTime=true
           ENVIRONMENT: development
           TZ: UTC
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/aldy505/asciitxt v0.0.2
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/getsentry/sentry-go v0.16.0
+	github.com/go-sql-driver/mysql v1.7.0
 	github.com/joho/godotenv v1.4.0
+	github.com/lib/pq v1.10.7
 	github.com/pkg/errors v0.9.1
 	github.com/rollbar/rollbar-go v1.4.5
 	github.com/rs/zerolog v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvSc
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -277,6 +279,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
+github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/locale/en.go
+++ b/locale/en.go
@@ -1,10 +1,23 @@
 package locale
 
 var EN map[Message]string = map[Message]string{
-	MessageWelcome:                "Hi, {{user}}!\n\nWelcome to {{group}}. Make sure you read pinned message first.",
-	MessageKick:                   "{{user}} has been kicked because he didn't complete the captcha.",
-	MessageJoin:                   "Hi, {{user}}!\n\nBefore you continue, please complete this captcha. You have 1 minute from now.\n\n{{captcha}}",
+	MessageWelcome: "Hi, {{user}}!\n\nWelcome to {{group}}. Make sure you read pinned message first.",
+
+	MessageKick: "{{user}} has been kicked because he didn't complete the captcha.",
+
+	MessageJoin: "Hi, {{user}}!\n\nBefore you continue, please complete this captcha. You have 1 minute from now.\n\n{{captcha}}",
+
 	MessageWrongAnswerLettersOnly: "Wrong answer. Only letters are allowed. You have {{remaining}} seconds left to complete.",
-	MessageWrongAnswer:            "Wrong answer, please try again. You have {{remaining}} seconds left to complete.",
-	MessageNonText:                "Hi, {{user}}. Complete the captcha first. You have {{remaining}} seconds left.",
+
+	MessageWrongAnswer: "Wrong answer, please try again. You have {{remaining}} seconds left to complete.",
+
+	MessageNonText: "Hi, {{user}}. Complete the captcha first. You have {{remaining}} seconds left.",
+
+	MessageUnderAttackOnlyAdmin: "Only groups admin that is allowed to execute this command. It is advised to contact them directly.",
+
+	MessageUnderAttackAlreadyEnabled: "Under attack mode is in effect. To stop, send /disableunderattack",
+
+	MessageUnderAttackStarting: "This groups is on under attack mode until {{expiresAt}}. " +
+		"Every user that is joining the group will be banned forever. " +
+		"To be able to join, wait until under attack mode is finished, or contact group admin.",
 }

--- a/locale/id.go
+++ b/locale/id.go
@@ -1,10 +1,28 @@
 package locale
 
 var ID map[Message]string = map[Message]string{
-	MessageWelcome:                "Halo, {{user}}!\n\nSelamat datang di {{group}}. Pastikan kamu baca pinned message ya.",
-	MessageKick:                   "{{user}} telah di kick karena tidak menyelesaikan captcha.",
-	MessageJoin:                   "Halo, {{user}}!\n\nSebelum melanjutkan, selesaikan captcha ini dulu. Kamu punya waktu 1 menit dari sekarang.\n\n{{captcha}}",
-	MessageWrongAnswerLettersOnly: "Jawaban captcha salah. Hanya huruf saja yang diperbolehkan. Kamu punya {{remaining}} detik lagi untuk menyelesaikan.",
-	MessageWrongAnswer:            "Jawaban captcha salah, harap coba lagi. Kamu punya {{remaining}} detik lagi untuk menyelesaikan.",
-	MessageNonText:                "Hai, {{user}}. Selesaikan captcha terlebih dahulu ya. Kamu punya waktu {{remaining}} detik lagi.",
+	MessageWelcome: "Halo, {{user}}!\n\nSelamat datang di {{group}}. Pastikan kamu baca pinned message ya.",
+
+	MessageKick: "{{user}} telah di kick karena tidak menyelesaikan captcha.",
+
+	MessageJoin: "Halo, {{user}}!\n\nSebelum melanjutkan, selesaikan captcha ini dulu. " +
+		"Kamu punya waktu 1 menit dari sekarang.\n\n{{captcha}}",
+
+	MessageWrongAnswerLettersOnly: "Jawaban captcha salah. Hanya huruf saja yang diperbolehkan. " +
+		"Kamu punya {{remaining}} detik lagi untuk menyelesaikan.",
+
+	MessageWrongAnswer: "Jawaban captcha salah, harap coba lagi. " +
+		"Kamu punya {{remaining}} detik lagi untuk menyelesaikan.",
+
+	MessageNonText: "Hai, {{user}}. Selesaikan captcha terlebih dahulu ya. " +
+		"Kamu punya waktu {{remaining}} detik lagi.",
+
+	MessageUnderAttackOnlyAdmin: "Hanya admin grup yang dapat menjalankan command ini. " +
+		"Sebaiknya kamu hubungi admin yang bersangkutan.",
+
+	MessageUnderAttackAlreadyEnabled: "Mode under attack sudah menyala. Untuk memeatikan, kirim /disableunderattack",
+
+	MessageUnderAttackStarting: "Grup ini dalam kondisi under attack sampai pukul {{expiresAt}}. " +
+		"Semua yang baru masuk ke grup ini akan langsung di ban selamanya." +
+		"Untuk bisa bergabung, tunggu sampai mode under attack berakhir, atau hubungi admin.",
 }

--- a/locale/locale.go
+++ b/locale/locale.go
@@ -9,4 +9,9 @@ const (
 	MessageWrongAnswerLettersOnly
 	MessageWrongAnswer
 	MessageNonText
+
+	// MessageUnderAttack represent the under attack module
+	MessageUnderAttackOnlyAdmin
+	MessageUnderAttackAlreadyEnabled
+	MessageUnderAttackStarting
 )

--- a/underattack/are_we.go
+++ b/underattack/are_we.go
@@ -1,0 +1,47 @@
+package underattack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/allegro/bigcache/v3"
+)
+
+// AreWe ...on under attack mode?
+func (d *Dependency) AreWe(ctx context.Context, chatID int64) (bool, error) {
+	underAttackCache, err := d.Memory.Get("underattack:" + strconv.FormatInt(chatID, 10))
+	if err != nil && !errors.Is(err, bigcache.ErrEntryNotFound) {
+		return false, err
+	}
+
+	if err == nil {
+		var entry UnderAttack
+		err := json.Unmarshal(underAttackCache, &entry)
+		if err != nil {
+			return false, err
+		}
+
+		return entry.IsUnderAttack && entry.ExpiresAt.After(time.Now()), nil
+	}
+
+	// Cache was not found
+	underAttackEntry, err := d.Datastore.GetUnderAttackEntry(ctx, chatID)
+	if err != nil {
+		return false, err
+	}
+
+	marshaledEntry, err := json.Marshal(underAttackEntry)
+	if err != nil {
+		return false, err
+	}
+
+	err = d.Memory.Set("underattack:"+strconv.FormatInt(chatID, 10), marshaledEntry)
+	if err != nil {
+		return false, err
+	}
+
+	return underAttackEntry.IsUnderAttack && underAttackEntry.ExpiresAt.After(time.Now()), nil
+}

--- a/underattack/datastore.go
+++ b/underattack/datastore.go
@@ -1,0 +1,14 @@
+package underattack
+
+import (
+	"context"
+	"time"
+)
+
+type Datastore interface {
+	Migrate(ctx context.Context) error
+	GetUnderAttackEntry(ctx context.Context, groupID int64) (UnderAttack, error)
+	CreateNewEntry(ctx context.Context, groupID int64) error
+	SetUnderAttackStatus(ctx context.Context, groupID int64, underAttack bool, expiresAt time.Time, notificationMessageID int64) error
+	Close() error
+}

--- a/underattack/datastore/memory/memory.go
+++ b/underattack/datastore/memory/memory.go
@@ -1,0 +1,108 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"captcha-lite/logger"
+	"captcha-lite/underattack"
+
+	"github.com/allegro/bigcache/v3"
+)
+
+type memoryDatastore struct {
+	db     *bigcache.BigCache
+	logger logger.Logger
+}
+
+func NewInMemoryDatastore(db *bigcache.BigCache, logger logger.Logger) (*memoryDatastore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+
+	if logger == nil {
+		return nil, fmt.Errorf("nil logger")
+	}
+
+	return &memoryDatastore{db: db, logger: logger}, nil
+}
+
+func (m *memoryDatastore) Migrate(ctx context.Context) error {
+	// Nothing to migrate
+	return nil
+}
+
+func (m *memoryDatastore) GetUnderAttackEntry(ctx context.Context, groupID int64) (underattack.UnderAttack, error) {
+	value, err := m.db.Get(strconv.FormatInt(groupID, 10))
+	if err != nil {
+		if errors.Is(err, bigcache.ErrEntryNotFound) {
+			go func(groupID int64) {
+				time.Sleep(time.Second * 5)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+				defer cancel()
+
+				err := m.CreateNewEntry(ctx, groupID)
+				if err != nil {
+					m.logger.HandleError(err)
+				}
+			}(groupID)
+
+			return underattack.UnderAttack{}, nil
+		}
+
+		return underattack.UnderAttack{}, err
+	}
+
+	var entry underattack.UnderAttack
+	err = json.Unmarshal(value, &entry)
+	if err != nil {
+		return underattack.UnderAttack{}, err
+	}
+
+	return entry, nil
+}
+
+func (m *memoryDatastore) CreateNewEntry(ctx context.Context, groupID int64) error {
+	if _, err := m.db.Get(strconv.FormatInt(groupID, 10)); err != nil {
+		// Do nothing if already exists
+		return nil
+	}
+
+	// Set a new one if not exists
+	value, err := json.Marshal(underattack.UnderAttack{
+		GroupID:               groupID,
+		IsUnderAttack:         false,
+		NotificationMessageID: 0,
+		ExpiresAt:             time.Time{},
+		UpdatedAt:             time.Now(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return m.db.Set(strconv.FormatInt(groupID, 10), value)
+}
+
+func (m *memoryDatastore) SetUnderAttackStatus(ctx context.Context, groupID int64, underAttack bool, expiresAt time.Time, notificationMessageID int64) error {
+	// Set a new one if not exists
+	value, err := json.Marshal(underattack.UnderAttack{
+		GroupID:               groupID,
+		IsUnderAttack:         underAttack,
+		NotificationMessageID: notificationMessageID,
+		ExpiresAt:             expiresAt,
+		UpdatedAt:             time.Now(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return m.db.Set(strconv.FormatInt(groupID, 10), value)
+}
+
+func (m *memoryDatastore) Close() error {
+	return m.db.Close()
+}

--- a/underattack/datastore/memory/memory_test.go
+++ b/underattack/datastore/memory/memory_test.go
@@ -1,0 +1,146 @@
+package memory_test
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"captcha-lite/logger/noop"
+	"captcha-lite/underattack"
+	"captcha-lite/underattack/datastore/memory"
+
+	"github.com/allegro/bigcache/v3"
+)
+
+var dependency underattack.Datastore
+
+func TestMain(m *testing.M) {
+	db, err := bigcache.New(context.Background(), bigcache.DefaultConfig(time.Hour))
+	if err != nil {
+		log.Fatalf("Creating bigcache instance: %s", err.Error())
+	}
+
+	dependency, err = memory.NewInMemoryDatastore(db, noop.New())
+	if err != nil {
+		log.Fatalf("creating new postgres datastore: %s", err.Error())
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), time.Second*30)
+
+	err = dependency.Migrate(setupCtx)
+	if err != nil {
+		log.Fatalf("migrating tables: %s", err.Error())
+	}
+
+	err = Seed(setupCtx, db)
+	if err != nil {
+		log.Fatalf("seeding data: %s", err.Error())
+	}
+
+	exitCode := m.Run()
+
+	setupCancel()
+
+	err = dependency.Close()
+	if err != nil {
+		log.Printf("closing postgres database: %s", err.Error())
+	}
+
+	os.Exit(exitCode)
+}
+
+func Seed(ctx context.Context, db *bigcache.BigCache) error {
+	value, err := json.Marshal(underattack.UnderAttack{
+		GroupID:               1,
+		IsUnderAttack:         true,
+		NotificationMessageID: 1002,
+		ExpiresAt:             time.Now().Add(time.Hour),
+		UpdatedAt:             time.Now(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return db.Set("1", value)
+}
+
+func TestNewMySQLDatastore(t *testing.T) {
+	t.Run("Nil DB", func(t *testing.T) {
+		_, err := memory.NewInMemoryDatastore(nil, nil)
+		if err.Error() != "nil db" {
+			t.Errorf("expecting an error of 'nil db', instead got %s", err.Error())
+		}
+	})
+
+	t.Run("Nil logger", func(t *testing.T) {
+		_, err := memory.NewInMemoryDatastore(&bigcache.BigCache{}, nil)
+		if err.Error() != "nil logger" {
+			t.Errorf("expecting an error of 'nil logger', instead got %s", err.Error())
+		}
+	})
+}
+
+func TestMigrate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.Migrate(ctx)
+	if err != nil {
+		t.Errorf("migrating database: %s", err.Error())
+	}
+}
+
+func TestGetUnderAttackEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	entry, err := dependency.GetUnderAttackEntry(ctx, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if entry.IsUnderAttack == false {
+		t.Error("expecting IsUnderAttack to be true, got false")
+	}
+
+	if entry.ExpiresAt.Before(time.Now()) {
+		t.Errorf("expecting ExpiresAt to be after now, got: %v", entry.ExpiresAt)
+	}
+
+	if entry.NotificationMessageID != 1002 {
+		t.Errorf("expecting NotificationMessageID to be 1002, got: %v", entry.NotificationMessageID)
+	}
+}
+
+func TestGetUnderAttackEntry_NotExists(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	_, err := dependency.GetUnderAttackEntry(ctx, 20)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateNewEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.CreateNewEntry(ctx, 2)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetUnderAttackStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.SetUnderAttackStatus(ctx, 3, true, time.Now().Add(time.Minute*30), 1003)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/underattack/datastore/mysql/mysql.go
+++ b/underattack/datastore/mysql/mysql.go
@@ -1,0 +1,288 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"captcha-lite/logger"
+	"captcha-lite/underattack"
+)
+
+type mysqlDatastore struct {
+	db     *sql.DB
+	logger logger.Logger
+}
+
+func NewMySQLDatastore(db *sql.DB, logger logger.Logger) (*mysqlDatastore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+
+	if logger == nil {
+		return nil, fmt.Errorf("nil logger")
+	}
+
+	return &mysqlDatastore{db: db, logger: logger}, nil
+}
+
+// Migrate will migrates database tables for under attack domain.
+func (m *mysqlDatastore) Migrate(ctx context.Context) error {
+	c, err := m.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			m.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`CREATE TABLE IF NOT EXISTS under_attack (
+			group_id BIGINT PRIMARY KEY,
+			is_under_attack BOOLEAN NOT NULL,
+			expires_at DATETIME NOT NULL,
+			notification_message_id BIGINT NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`,
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+	_, err = tx.ExecContext(
+		ctx,
+		`CREATE INDEX idx_updated_at ON under_attack (updated_at)`,
+	)
+	if err != nil && !strings.Contains(err.Error(), "Duplicate key name") {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// GetUnderAttackEntry will acquire under attack entry for specified groupID.
+func (m *mysqlDatastore) GetUnderAttackEntry(ctx context.Context, groupID int64) (underattack.UnderAttack, error) {
+	c, err := m.db.Conn(ctx)
+	if err != nil {
+		return underattack.UnderAttack{}, err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			m.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted, ReadOnly: true})
+	if err != nil {
+		return underattack.UnderAttack{}, err
+	}
+
+	var entry underattack.UnderAttack
+
+	err = tx.QueryRowContext(
+		ctx,
+		`SELECT
+    	group_id,
+    	is_under_attack,
+    	expires_at,
+    	notification_message_id,
+    	updated_at
+    FROM
+        under_attack
+    WHERE
+        group_id = ?
+    ORDER BY
+        updated_at DESC`,
+		groupID,
+	).Scan(
+		&entry.GroupID,
+		&entry.IsUnderAttack,
+		&entry.ExpiresAt,
+		&entry.NotificationMessageID,
+		&entry.UpdatedAt,
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return underattack.UnderAttack{}, e
+		}
+
+		if errors.Is(err, sql.ErrNoRows) {
+			go func(groupID int64) {
+				time.Sleep(time.Second * 5)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+				defer cancel()
+
+				err := m.CreateNewEntry(ctx, groupID)
+				if err != nil {
+					m.logger.HandleError(err)
+				}
+			}(groupID)
+
+			return underattack.UnderAttack{}, nil
+		}
+
+		return underattack.UnderAttack{}, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return underattack.UnderAttack{}, e
+		}
+
+		return underattack.UnderAttack{}, err
+	}
+
+	return entry, nil
+}
+
+// CreateNewEntry will create a new entry for given groupID.
+// This should only be executed if the group entry does not exists on the database.
+// If it already exists, it will do nothing.
+func (m *mysqlDatastore) CreateNewEntry(ctx context.Context, groupID int64) error {
+	c, err := m.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			m.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+		VALUES
+			(?, ?, ?, ?)
+		ON DUPLICATE KEY
+		UPDATE
+		    group_id = group_id`,
+		groupID,
+		false,
+		time.Time{},
+		0,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// SetUnderAttackStatus will update the given groupID entry to the given parameters.
+// If the groupID entry does not exists, it will create a new one.
+func (m *mysqlDatastore) SetUnderAttackStatus(ctx context.Context, groupID int64, underAttack bool, expiresAt time.Time, notificationMessageID int64) error {
+	c, err := m.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			m.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+		VALUES
+			(?, ?, ?, ?, ?)
+		ON DUPLICATE KEY
+		UPDATE
+			is_under_attack = ?,
+			expires_at = ?,
+			notification_message_id = ?,
+			updated_at = ?`,
+		groupID,
+		underAttack,
+		expiresAt,
+		notificationMessageID,
+		time.Now(),
+		underAttack,
+		expiresAt,
+		notificationMessageID,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (m *mysqlDatastore) Close() error {
+	return m.db.Close()
+}

--- a/underattack/datastore/mysql/mysql.go
+++ b/underattack/datastore/mysql/mysql.go
@@ -197,7 +197,7 @@ func (m *mysqlDatastore) CreateNewEntry(ctx context.Context, groupID int64) erro
 		    group_id = group_id`,
 		groupID,
 		false,
-		time.Time{},
+		time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC),
 		0,
 		time.Now(),
 	)

--- a/underattack/datastore/mysql/mysql.go
+++ b/underattack/datastore/mysql/mysql.go
@@ -191,7 +191,7 @@ func (m *mysqlDatastore) CreateNewEntry(ctx context.Context, groupID int64) erro
 			under_attack
 			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
 		VALUES
-			(?, ?, ?, ?)
+			(?, ?, ?, ?, ?)
 		ON DUPLICATE KEY
 		UPDATE
 		    group_id = group_id`,

--- a/underattack/datastore/mysql/mysql_test.go
+++ b/underattack/datastore/mysql/mysql_test.go
@@ -1,0 +1,186 @@
+package mysql_test
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"captcha-lite/logger/noop"
+	"captcha-lite/underattack"
+	"captcha-lite/underattack/datastore/mysql"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var dependency underattack.Datastore
+
+func TestMain(m *testing.M) {
+	mysqlUrl, ok := os.LookupEnv("MYSQL_URL")
+	if !ok {
+		mysqlUrl = "captcha:password@tcp(localhost:3306)/captcha?parseTime=true"
+	}
+
+	db, err := sql.Open("mysql", mysqlUrl)
+	if err != nil {
+		log.Fatalf("opening postgres: %s", err.Error())
+	}
+
+	dependency, err = mysql.NewMySQLDatastore(db, noop.New())
+	if err != nil {
+		log.Fatalf("creating new postgres datastore: %s", err.Error())
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), time.Second*30)
+
+	err = dependency.Migrate(setupCtx)
+	if err != nil {
+		log.Fatalf("migrating tables: %s", err.Error())
+	}
+
+	err = Seed(setupCtx, db)
+	if err != nil {
+		log.Fatalf("seeding data: %s", err.Error())
+	}
+	
+	exitCode := m.Run()
+
+	setupCancel()
+
+	err = dependency.Close()
+	if err != nil {
+		log.Printf("closing postgres database: %s", err.Error())
+	}
+
+	os.Exit(exitCode)
+}
+
+func Seed(ctx context.Context, db *sql.DB) error {
+	c, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+			VALUES
+			(?, ?, ?, ?, ?)`,
+		1,
+		true,
+		time.Now().Add(time.Hour*1),
+		1002,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func TestNewMySQLDatastore(t *testing.T) {
+	t.Run("Nil DB", func(t *testing.T) {
+		_, err := mysql.NewMySQLDatastore(nil, nil)
+		if err.Error() != "nil db" {
+			t.Errorf("expecting an error of 'nil db', instead got %s", err.Error())
+		}
+	})
+
+	t.Run("Nil logger", func(t *testing.T) {
+		_, err := mysql.NewMySQLDatastore(&sql.DB{}, nil)
+		if err.Error() != "nil logger" {
+			t.Errorf("expecting an error of 'nil logger', instead got %s", err.Error())
+		}
+	})
+}
+
+func TestMigrate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.Migrate(ctx)
+	if err != nil {
+		t.Errorf("migrating database: %s", err.Error())
+	}
+}
+
+func TestGetUnderAttackEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	entry, err := dependency.GetUnderAttackEntry(ctx, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if entry.IsUnderAttack == false {
+		t.Error("expecting IsUnderAttack to be true, got false")
+	}
+
+	if entry.ExpiresAt.Before(time.Now()) {
+		t.Errorf("expecting ExpiresAt to be after now, got: %v", entry.ExpiresAt)
+	}
+
+	if entry.NotificationMessageID != 1002 {
+		t.Errorf("expecting NotificationMessageID to be 1002, got: %v", entry.NotificationMessageID)
+	}
+}
+
+func TestGetUnderAttackEntry_NotExists(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	_, err := dependency.GetUnderAttackEntry(ctx, 20)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateNewEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.CreateNewEntry(ctx, 2)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetUnderAttackStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.SetUnderAttackStatus(ctx, 3, true, time.Now().Add(time.Minute*30), 1003)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/underattack/datastore/postgres/postgres.go
+++ b/underattack/datastore/postgres/postgres.go
@@ -1,0 +1,283 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"captcha-lite/logger"
+	"captcha-lite/underattack"
+)
+
+type postgresDatastore struct {
+	db     *sql.DB
+	logger logger.Logger
+}
+
+func NewPostgresDatastore(db *sql.DB, logger logger.Logger) (*postgresDatastore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil db")
+	}
+
+	if logger == nil {
+		return nil, fmt.Errorf("nil logger")
+	}
+
+	return &postgresDatastore{db: db, logger: logger}, nil
+}
+
+// Migrate will migrates database tables for under attack domain.
+func (p *postgresDatastore) Migrate(ctx context.Context) error {
+	c, err := p.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			p.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`CREATE TABLE IF NOT EXISTS under_attack (
+			group_id BIGINT PRIMARY KEY,
+			is_under_attack BOOLEAN NOT NULL,
+			expires_at TIMESTAMP NOT NULL,
+			notification_message_id BIGINT NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		)`,
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+	_, err = tx.ExecContext(
+		ctx,
+		`CREATE INDEX IF NOT EXISTS idx_updated_at ON under_attack (updated_at)`,
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return err
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// GetUnderAttackEntry will acquire under attack entry for specified groupID.
+func (p *postgresDatastore) GetUnderAttackEntry(ctx context.Context, groupID int64) (underattack.UnderAttack, error) {
+	c, err := p.db.Conn(ctx)
+	if err != nil {
+		return underattack.UnderAttack{}, err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			p.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted, ReadOnly: true})
+	if err != nil {
+		return underattack.UnderAttack{}, err
+	}
+
+	var entry underattack.UnderAttack
+
+	err = tx.QueryRowContext(
+		ctx,
+		`SELECT
+    	group_id,
+    	is_under_attack,
+    	expires_at,
+    	notification_message_id,
+    	updated_at
+    FROM
+        under_attack
+    WHERE
+        group_id = $1
+    ORDER BY
+        updated_at DESC`,
+		groupID,
+	).Scan(
+		&entry.GroupID,
+		&entry.IsUnderAttack,
+		&entry.ExpiresAt,
+		&entry.NotificationMessageID,
+		&entry.UpdatedAt,
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return underattack.UnderAttack{}, e
+		}
+
+		if errors.Is(err, sql.ErrNoRows) {
+			go func(groupID int64) {
+				time.Sleep(time.Second * 5)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+				defer cancel()
+
+				err := p.CreateNewEntry(ctx, groupID)
+				if err != nil {
+					p.logger.HandleError(err)
+				}
+			}(groupID)
+
+			return underattack.UnderAttack{}, nil
+		}
+
+		return underattack.UnderAttack{}, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return underattack.UnderAttack{}, e
+		}
+
+		return underattack.UnderAttack{}, err
+	}
+
+	return entry, nil
+}
+
+// CreateNewEntry will create a new entry for given groupID.
+// This should only be executed if the group entry does not exists on the database.
+// If it already exists, it will do nothing.
+func (p *postgresDatastore) CreateNewEntry(ctx context.Context, groupID int64) error {
+	c, err := p.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			p.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+		VALUES
+			($1, $2, $3, $4, $5)
+		ON CONFLICT (group_id)
+		DO NOTHING`,
+		groupID,
+		false,
+		time.Time{},
+		0,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// SetUnderAttackStatus will update the given groupID entry to the given parameters.
+// If the groupID entry does not exists, it will create a new one.
+func (p *postgresDatastore) SetUnderAttackStatus(ctx context.Context, groupID int64, underAttack bool, expiresAt time.Time, notificationMessageID int64) error {
+	c, err := p.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil && !errors.Is(err, sql.ErrConnDone) {
+			p.logger.HandleError(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+		VALUES
+			($1, $2, $3, $4, $5)
+		ON CONFLICT (group_id)
+		DO UPDATE
+		SET
+			is_under_attack = $2,
+			expires_at = $3,
+			notification_message_id = $4,
+			updated_at = $5`,
+		groupID,
+		underAttack,
+		expiresAt,
+		notificationMessageID,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *postgresDatastore) Close() error {
+	return p.db.Close()
+}

--- a/underattack/datastore/postgres/postgres_test.go
+++ b/underattack/datastore/postgres/postgres_test.go
@@ -1,0 +1,186 @@
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"captcha-lite/logger/noop"
+	"captcha-lite/underattack"
+	"captcha-lite/underattack/datastore/postgres"
+
+	_ "github.com/lib/pq"
+)
+
+var dependency underattack.Datastore
+
+func TestMain(m *testing.M) {
+	postgresUrl, ok := os.LookupEnv("POSTGRES_URL")
+	if !ok {
+		postgresUrl = "postgres://captcha:password@localhost:5432/captcha?sslmode=disable"
+	}
+
+	db, err := sql.Open("postgres", postgresUrl)
+	if err != nil {
+		log.Fatalf("opening postgres: %s", err.Error())
+	}
+
+	dependency, err = postgres.NewPostgresDatastore(db, noop.New())
+	if err != nil {
+		log.Fatalf("creating new postgres datastore: %s", err.Error())
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), time.Second*30)
+
+	err = dependency.Migrate(setupCtx)
+	if err != nil {
+		log.Fatalf("migrating tables: %s", err.Error())
+	}
+
+	err = Seed(setupCtx, db)
+	if err != nil {
+		log.Fatalf("seeding data: %s", err.Error())
+	}
+	
+	exitCode := m.Run()
+
+	setupCancel()
+
+	err = dependency.Close()
+	if err != nil {
+		log.Printf("closing postgres database: %s", err.Error())
+	}
+
+	os.Exit(exitCode)
+}
+
+func Seed(ctx context.Context, db *sql.DB) error {
+	c, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := c.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	tx, err := c.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO
+			under_attack
+			(group_id, is_under_attack, expires_at, notification_message_id, updated_at)
+			VALUES
+			($1, $2, $3, $4, $5)`,
+		1,
+		true,
+		time.Now().Add(time.Hour*1),
+		1002,
+		time.Now(),
+	)
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		if e := tx.Rollback(); e != nil {
+			return e
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func TestNewPostgresDatastore(t *testing.T) {
+	t.Run("Nil DB", func(t *testing.T) {
+		_, err := postgres.NewPostgresDatastore(nil, nil)
+		if err.Error() != "nil db" {
+			t.Errorf("expecting an error of 'nil db', instead got %s", err.Error())
+		}
+	})
+
+	t.Run("Nil logger", func(t *testing.T) {
+		_, err := postgres.NewPostgresDatastore(&sql.DB{}, nil)
+		if err.Error() != "nil logger" {
+			t.Errorf("expecting an error of 'nil logger', instead got %s", err.Error())
+		}
+	})
+}
+
+func TestMigrate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.Migrate(ctx)
+	if err != nil {
+		t.Errorf("migrating database: %s", err.Error())
+	}
+}
+
+func TestGetUnderAttackEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	entry, err := dependency.GetUnderAttackEntry(ctx, 1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if entry.IsUnderAttack == false {
+		t.Error("expecting IsUnderAttack to be true, got false")
+	}
+
+	if entry.ExpiresAt.Before(time.Now()) {
+		t.Errorf("expecting ExpiresAt to be after now, got: %v", entry.ExpiresAt)
+	}
+
+	if entry.NotificationMessageID != 1002 {
+		t.Errorf("expecting NotificationMessageID to be 1002, got: %v", entry.NotificationMessageID)
+	}
+}
+
+func TestGetUnderAttackEntry_NotExists(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	_, err := dependency.GetUnderAttackEntry(ctx, 20)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateNewEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.CreateNewEntry(ctx, 2)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetUnderAttackStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := dependency.SetUnderAttackStatus(ctx, 3, true, time.Now().Add(time.Minute*30), 1003)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/underattack/handler.go
+++ b/underattack/handler.go
@@ -1,0 +1,181 @@
+package underattack
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"captcha-lite/locale"
+	"captcha-lite/utils"
+
+	tb "gopkg.in/telebot.v3"
+)
+
+// EnableUnderAttackModeHandler provides a handler for /underattack command.
+func (d *Dependency) EnableUnderAttackModeHandler(c tb.Context) error {
+	if c.Message().Private() || c.Sender().IsBot {
+		return nil
+	}
+
+	admins, err := c.Bot().AdminsOf(c.Chat())
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	if !utils.IsAdmin(admins, c.Sender()) {
+		_, err := c.Bot().Send(
+			c.Chat(),
+			d.Locale[locale.MessageUnderAttackOnlyAdmin],
+			&tb.SendOptions{
+				ReplyTo:           c.Message(),
+				AllowWithoutReply: true,
+			},
+		)
+		if err != nil {
+			d.Logger.HandleBotError(err, d.Bot, c.Message())
+			return nil
+		}
+
+		return nil
+	}
+
+	// Sender must be an admin here.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
+	defer cancel()
+
+	// Check if we are on the under attack mode right now.
+	underAttackModeEnabled, err := d.AreWe(ctx, c.Chat().ID)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	if underAttackModeEnabled {
+		_, err := c.Bot().Send(
+			c.Chat(),
+			d.Locale[locale.MessageUnderAttackAlreadyEnabled],
+			&tb.SendOptions{
+				ReplyTo:           c.Message(),
+				AllowWithoutReply: true,
+			},
+		)
+		if err != nil {
+			d.Logger.HandleBotError(err, d.Bot, c.Message())
+			return nil
+		}
+
+		return nil
+	}
+
+	expiresAt := time.Now().Add(time.Minute * 30)
+
+	notificationMessage, err := c.Bot().Send(
+		c.Chat(),
+		strings.Replace(
+			d.Locale[locale.MessageUnderAttackStarting],
+			"{{expiresAt}}",
+			expiresAt.In(time.UTC).Format("15:04 MST"),
+			1,
+		),
+		&tb.SendOptions{
+			ParseMode: tb.ModeDefault,
+		},
+	)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = d.Datastore.SetUnderAttackStatus(ctx, c.Chat().ID, true, time.Now().Add(time.Minute*30), int64(notificationMessage.ID))
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = d.Memory.Delete("underattack:" + strconv.FormatInt(c.Chat().ID, 10))
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = c.Bot().Pin(notificationMessage)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	return nil
+}
+
+// DisableUnderAttackModeHandler provides a handler for /disableunderattack command.
+func (d *Dependency) DisableUnderAttackModeHandler(c tb.Context) error {
+	if c.Message().Private() || c.Sender().IsBot {
+		return nil
+	}
+
+	admins, err := c.Bot().AdminsOf(c.Chat())
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	if !utils.IsAdmin(admins, c.Sender()) {
+		_, err := c.Bot().Send(
+			c.Chat(),
+			d.Locale[locale.MessageUnderAttackOnlyAdmin],
+			&tb.SendOptions{
+				ReplyTo:           c.Message(),
+				AllowWithoutReply: true,
+			},
+		)
+		if err != nil {
+			d.Logger.HandleBotError(err, d.Bot, c.Message())
+			return nil
+		}
+
+		return nil
+	}
+
+	// Sender must be an admin here.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
+	defer cancel()
+
+	// Check if we are on the under attack mode right now.
+	underAttackModeEnabled, err := d.AreWe(ctx, c.Chat().ID)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	if !underAttackModeEnabled {
+		return nil
+	}
+
+	underAttackEntry, err := d.Datastore.GetUnderAttackEntry(ctx, c.Chat().ID)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = d.Datastore.SetUnderAttackStatus(ctx, c.Chat().ID, false, time.Now(), 0)
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = d.Memory.Delete("underattack:" + strconv.FormatInt(c.Chat().ID, 10))
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	err = c.Bot().Unpin(c.Chat(), int(underAttackEntry.NotificationMessageID))
+	if err != nil {
+		d.Logger.HandleBotError(err, d.Bot, c.Message())
+		return nil
+	}
+
+	return nil
+}

--- a/underattack/underattack.go
+++ b/underattack/underattack.go
@@ -1,0 +1,31 @@
+package underattack
+
+import (
+	"time"
+
+	"captcha-lite/locale"
+	"captcha-lite/logger"
+
+	"github.com/allegro/bigcache/v3"
+	tb "gopkg.in/telebot.v3"
+)
+
+// Dependency contains the dependency injection struct
+// for methods in the UnderAttack package
+type Dependency struct {
+	Datastore Datastore
+	Memory    *bigcache.BigCache
+	Bot       *tb.Bot
+	Logger    logger.Logger
+	Locale    map[locale.Message]string
+}
+
+// UnderAttack provides a data struct to interact with
+// the database table.
+type UnderAttack struct {
+	GroupID               int64     `db:"group_id"`
+	IsUnderAttack         bool      `db:"is_under_attack"`
+	NotificationMessageID int64     `db:"notification_message_id"`
+	ExpiresAt             time.Time `db:"expires_at"`
+	UpdatedAt             time.Time `db:"updated_at"`
+}


### PR DESCRIPTION
This PR brings the experimental and tested feature from the original captcha bot of under attack mode.

Usage:

```sh
export UNDER_ATTACK_DATASTORE_PROVIDER=memory   # Valid options: postgres, mysql, memory
export UNDER_ATTACK_DATASTORE_DSN=              # Should be filled with the DSN to the database (if any)

./captcha-lite --experimental-underattack=true
```

